### PR TITLE
bitv: Avoid undefined behavior in mask_for_bits

### DIFF
--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -177,7 +177,7 @@ fn blocks_for_bits(bits: uint) -> uint {
 /// Computes the bitmask for the final word of the vector
 fn mask_for_bits(bits: uint) -> u32 {
     // Note especially that a perfect multiple of u32::BITS should mask all 1s.
-    !0u32 >> (u32::BITS - bits % u32::BITS)
+    !0u32 >> (u32::BITS - bits % u32::BITS) % u32::BITS
 }
 
 impl Bitv {


### PR DESCRIPTION
It was relying on the fact that x86 shifts are effectively %BITS, so
shifting a u32 by 32 preserves all bits.  But this is undefined behavior
in general.  Add an explicit %BITS to be safe.
